### PR TITLE
Fix missing indexField for site listing grid

### DIFF
--- a/view/adminhtml/ui_component/mooore_wordpressintegration_site_listing.xml
+++ b/view/adminhtml/ui_component/mooore_wordpressintegration_site_listing.xml
@@ -23,6 +23,9 @@
     </settings>
     <dataSource component="Magento_Ui/js/grid/provider" name="mooore_wordpressintegration_site_listing_data_source">
         <settings>
+            <storageConfig>
+                <param name="indexField" xsi:type="string">site_id</param>
+            </storageConfig>
             <updateUrl path="mui/index/render"/>
         </settings>
         <aclResource>Mooore_WordpressIntegration::Site</aclResource>


### PR DESCRIPTION
A setting is missing in the dataSource configuration when the indexField is not equal to entity_id. When paging through a grid, the results are cached by their IDs. Consequently, the resolving of the IDs will result unwanted behavior.