### PR TITLE
CON-226 - Add settings for blog

### DIFF
--- a/Api/Data/SiteInterface.php
+++ b/Api/Data/SiteInterface.php
@@ -15,6 +15,9 @@ interface SiteInterface extends ExtensibleDataInterface
     const SITE_ID = 'site_id';
     const API_USERNAME = 'api_username';
     const API_PASSWORD = 'api_password';
+    const ENABLE_BLOG = 'enable_blog';
+    const BLOG_PREFIX = 'blog_prefix';
+    const BLOG_STORES = 'blog_stores';
 
     /**
      * Get site_id
@@ -106,4 +109,43 @@ interface SiteInterface extends ExtensibleDataInterface
      * @return SiteInterface
      */
     public function setApiPassword(?string $apiPassword);
+
+    /**
+     * Get enable_blog
+     * @return bool
+     */
+    public function getEnableBlog(): ?bool;
+
+    /**
+     * Set enable_blog
+     * @param bool $enableBlog
+     * @return SiteInterface
+     */
+    public function setEnableBlog(?bool $enableBlog);
+
+    /**
+     * Get blog_prefix
+     * @return string
+     */
+    public function getBlogPrefix(): ?string;
+
+    /**
+     * Set blog_prefix
+     * @param string $blogPrefix
+     * @return SiteInterface
+     */
+    public function setBlogPrefix(?string $blogPrefix);
+
+    /**
+     * Get blog_stores
+     * @return string
+     */
+    public function getBlogStores(): string;
+
+    /**
+     * Set blog_stores
+     * @param string $blogStores
+     * @return SiteInterface
+     */
+    public function setBlogStores(string $blogStores);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added site settings to enable the media URL replace option
+- Add basic blog functionality
 
 ## [0.3.0] - 2021-02-10
 ### Added

--- a/Controller/Adminhtml/Site/Save.php
+++ b/Controller/Adminhtml/Site/Save.php
@@ -53,6 +53,8 @@ class Save extends Action
             return $resultRedirect->setPath('*/*/');
         }
 
+        $data['blog_stores'] = is_array($data['blog_stores']) ? join(',', $data['blog_stores']) : $data['blog_stores'];
+
         $model->setData($data);
 
         try {

--- a/Model/Data/Site.php
+++ b/Model/Data/Site.php
@@ -142,4 +142,68 @@ class Site extends AbstractExtensibleObject implements SiteInterface
     {
         return $this->setData(self::API_PASSWORD, $apiPassword);
     }
+
+    /**
+     * Get enable_blog
+     * @return bool|null
+     */
+    public function getEnableBlog(): bool
+    {
+        return (bool) $this->_get(self::ENABLE_BLOG);
+    }
+
+    /**
+     * Set enable_blog
+     * @param bool $enableBlog
+     * @return SiteInterface
+     */
+    public function setEnableBlog($enableBlog)
+    {
+        return $this->setData(self::ENABLE_BLOG, $enableBlog);
+    }
+
+    /**
+     * - Add data rentation for route prefix + store views
+     * - Add check at cronjob per site to check which blog is enabled
+     * - Add check at cronjob for all stores to see which is applicable
+     * - Create rewrite URLs
+     */
+
+     /**
+     * Get blog_prefix
+     * @return string
+     */
+    public function getBlogPrefix(): ?string
+    {
+        return $this->_get(self::BLOG_PREFIX);
+    }
+
+    /**
+     * Set blog_prefix
+     * @param string $apiPassword
+     * @return SiteInterface
+     */
+    public function setBlogPrefix(?string $blogPrefix)
+    {
+        return $this->setData(self::BLOG_PREFIX, $blogPrefix);
+    }
+
+     /**
+     * Get blog_stores
+     * @return string
+     */
+    public function getBlogStores(): string
+    {
+        return $this->_get(self::BLOG_STORES);
+    }
+
+    /**
+     * Set blog_stores
+     * @param string $blogStores
+     * @return SiteInterface
+     */
+    public function setBlogStores(string $blogStores)
+    {
+        return $this->setData(self::BLOG_STORES, $blogStores);
+    }
 }

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -13,5 +13,8 @@
         <column default="1" name="enabled" nullable="false" xsi:type="boolean"/>
         <column length="255" name="api_username" nullable="true" xsi:type="varchar"/>
         <column length="255" name="api_password" nullable="true" xsi:type="varchar"/>
+        <column default="0" name="enable_blog" nullable="false" xsi:type="boolean"/>
+        <column length="255" name="blog_prefix" nullable="true" xsi:type="varchar"/>
+        <column length="255" name="blog_stores" nullable="false" xsi:type="varchar"/>
     </table>
 </schema>

--- a/view/adminhtml/ui_component/mooore_wordpressintegration_site_form.xml
+++ b/view/adminhtml/ui_component/mooore_wordpressintegration_site_form.xml
@@ -102,7 +102,7 @@
                 </validation>
             </settings>
         </field>
-        <field formElement="checkbox" name="enabled" sortOrder="50">
+        <field formElement="checkbox" name="enabled" sortOrder="9">
             <argument name="data" xsi:type="array">
                 <item name="config" xsi:type="array">
                     <item name="source" xsi:type="string">Site</item>
@@ -128,6 +128,104 @@
                     </settings>
                 </checkbox>
             </formElements>
+        </field>
+    </fieldset>
+    <fieldset name="blog">
+        <settings>
+            <label>Blog</label>
+        </settings>
+        <field formElement="checkbox" name="enable_blog" sortOrder="10">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">Site</item>
+                    <item name="default" xsi:type="number">0</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>boolean</dataType>
+                <label translate="true">Enable Blog</label>
+                <dataScope>enable_blog</dataScope>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">false</rule>
+                </validation>
+                <switcherConfig>
+                    <enabled>true</enabled>
+                    <rules>
+                        <rule name="0">
+                            <value>0</value>
+                            <actions>
+                                <action name="0">
+                                    <target>mooore_wordpressintegration_site_form.mooore_wordpressintegration_site_form.blog.blog_prefix</target>
+                                    <callback>hide</callback>
+                                </action>
+                                <action name="1">
+                                    <target>mooore_wordpressintegration_site_form.mooore_wordpressintegration_site_form.blog.blog_stores</target>
+                                    <callback>hide</callback>
+                                </action>
+                            </actions>
+                        </rule>
+                        <rule name="1">
+                            <value>1</value>
+                            <actions>
+                                <action name="0">
+                                    <target>mooore_wordpressintegration_site_form.mooore_wordpressintegration_site_form.blog.blog_prefix</target>
+                                    <callback>show</callback>
+                                </action>
+                                <action name="1">
+                                    <target>mooore_wordpressintegration_site_form.mooore_wordpressintegration_site_form.blog.blog_stores</target>
+                                    <callback>show</callback>
+                                </action>
+                            </actions>
+                        </rule>
+                    </rules>
+                </switcherConfig>
+            </settings>
+            <formElements>
+                <checkbox>
+                    <settings>
+                        <valueMap>
+                            <map name="false" xsi:type="number">0</map>
+                            <map name="true" xsi:type="number">1</map>
+                        </valueMap>
+                        <prefer>toggle</prefer>
+                    </settings>
+                </checkbox>
+            </formElements>
+        </field>
+        <field formElement="input" name="blog_prefix" sortOrder="20">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="source" xsi:type="string">Site</item>
+                </item>
+            </argument>
+            <settings>
+                <dataType>text</dataType>
+                <label translate="true">Blog Route Prefix</label>
+                <dataScope>blog_prefix</dataScope>
+                <notice translate="true">Allows you to set a default blog prefix, for example "/blog", leave this field empty to disable this feature.</notice>
+                <validation>
+                    <rule name="required-entry" xsi:type="boolean">false</rule>
+                </validation>
+            </settings>
+        </field>
+        <field name="blog_stores" sortOrder="30">
+            <argument name="data" xsi:type="array">
+                <item name="options" xsi:type="object">Magento\Cms\Ui\Component\Listing\Column\Cms\Options</item>
+                <item name="config" xsi:type="array">
+                    <item name="dataType" xsi:type="string">int</item>
+                    <item name="label" xsi:type="string" translate="true">Store View</item>
+                    <item name="formElement" xsi:type="string">multiselect</item>
+                    <item name="source" xsi:type="string">page</item>
+                    <item name="dataScope" xsi:type="string">blog_stores</item>
+                    <item name="default" xsi:type="string">0</item>
+                    <item name="validation" xsi:type="array">
+                        <item name="required-entry" xsi:type="boolean">true</item>
+                    </item>
+                </item>
+            </argument>
+            <settings>
+                <notice translate="true">Select which stores you want this blog site to be enabled.</notice>
+            </settings>
         </field>
     </fieldset>
 </form>


### PR DESCRIPTION
Adds various settings and data properties to assist in the `feature/CON-226` branch in the[ magento2-module-wordpress-integration-cms module](https://github.com/mooore-digital/magento2-module-wordpress-integration-cms/pull/82). :+1: 